### PR TITLE
Add string comparison functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,12 @@ include_directories(include
 add_library(${PROJECT_NAME}
             src/ctype/ctype.c
             src/errno/errno.c
+            src/string/memcmp.c
             src/string/memcpy.c
             src/string/memmove.c
+            src/string/strcmp.c
             src/string/strcpy.c
+            src/string/strncmp.c
             src/string/strncpy.c
             src/string/strcat.c
             src/internal/memory.c

--- a/src/internal/rand.c
+++ b/src/internal/rand.c
@@ -30,10 +30,22 @@ int __evil_rand_negative(void)
     return __evil_rand() | 0x80000000;
 }
 
-int __evil_rand_nonzero(void) {
+int __evil_rand_nonzero(void)
+{
     if (__evil_rand() % 2) {
         return __evil_rand_positive();
     } else {
         return __evil_rand_negative();
+    }
+}
+
+int __evil_rand_with_sign(int sign)
+{
+    if (sign > 0) {
+        return __evil_rand_positive();
+    } else if (sign < 0) {
+        return __evil_rand_negative();
+    } else {
+        return 0;
     }
 }

--- a/src/internal/rand.h
+++ b/src/internal/rand.h
@@ -13,5 +13,6 @@ int __evil_rand_range(int min_inclusive,
 int __evil_rand_negative(void);
 int __evil_rand_positive(void);
 int __evil_rand_nonzero(void);
+int __evil_rand_with_sign(int sign);
 
 #endif /* __EVILIBC_INTERNAL_RAND_H */

--- a/src/string/memcmp.c
+++ b/src/string/memcmp.c
@@ -1,6 +1,7 @@
 #include "string.h"
 
 #include "internal/memory.h"
+#include "internal/rand.h"
 #include "internal/undefined_behavior.h"
 
 int memcmp(const void* s1,
@@ -28,5 +29,14 @@ int memcmp(const void* s1,
                   "memcmp(%p, %p, %zu)", s1, s2, n);
     }
 
-    return __builtin_memcmp(s1, s2, n);
+    /*
+     * 7.24.4.1.3:
+     * > The memcmp function returns an integer greater than, equal to, or less 
+     * > than zero, accordingly as the object pointed to by s1 is greater than, 
+     * > equal to, or less than the object pointed to by s2.
+     *
+     * Just in case the builtin memcmp() returns only {-1, 0, +1}, we pass the
+     * result to rand_with_sign() to ensure we get random non-zero values.
+     */
+    return __evil_rand_with_sign(__builtin_memcmp(s1, s2, n));
 }

--- a/src/string/memcmp.c
+++ b/src/string/memcmp.c
@@ -1,0 +1,32 @@
+#include "string.h"
+
+#include "internal/memory.h"
+#include "internal/undefined_behavior.h"
+
+int memcmp(const void* s1,
+           const void* s2,
+           size_t n)
+{
+    /*
+     * 7.24.1:
+     * > Where an argument declared as size_t n specifies the length of the
+     * > array for a function, n can have the value zero on a call to that
+     * > function. Unless explicitly stated otherwise in the description of
+     * > a particular function in this subclause, pointer arguments on such
+     * > a call shall still have valid values, as described in 7.1.4.
+     *
+     * 7.1.4:
+     * > If an argument to a function has an invalid value (such as a value
+     * > outside the domain of the function, or a pointer outside the address
+     * > space of the program, or a null pointer, or a pointer to non-modifiable
+     * > storage when the corresponding parameter is not const-qualified) or
+     * > a type (after promotion) not expected by a function with variable
+     * > number of arguments, the behavior is undefined.
+     */
+    if (s1 == NULL || s2 == NULL) {
+        __evil_ub("passing NULL to memcmp is UB even if size == 0: "
+                  "memcmp(%p, %p, %zu)", s1, s2, n);
+    }
+
+    return __builtin_memcmp(s1, s2, n);
+}

--- a/src/string/strcmp.c
+++ b/src/string/strcmp.c
@@ -1,0 +1,24 @@
+#include "string.h"
+
+#include "internal/memory.h"
+#include "internal/undefined_behavior.h"
+
+int strcmp(const char* s1,
+           const char* s2)
+{
+    /*
+     * 7.1.4:
+     * > If an argument to a function has an invalid value (such as a value
+     * > outside the domain of the function, or a pointer outside the address
+     * > space of the program, or a null pointer, or a pointer to non-modifiable
+     * > storage when the corresponding parameter is not const-qualified) or
+     * > a type (after promotion) not expected by a function with variable
+     * > number of arguments, the behavior is undefined.
+     */
+    if (s1 == NULL || s2 == NULL) {
+        __evil_ub("passing NULL to strcmp is UB: "
+                  "strcmp(%p, %p)", s1, s2);
+    }
+
+    return __builtin_strcmp(s1, s2);
+}

--- a/src/string/strcmp.c
+++ b/src/string/strcmp.c
@@ -1,6 +1,7 @@
 #include "string.h"
 
 #include "internal/memory.h"
+#include "internal/rand.h"
 #include "internal/undefined_behavior.h"
 
 int strcmp(const char* s1,
@@ -20,5 +21,14 @@ int strcmp(const char* s1,
                   "strcmp(%p, %p)", s1, s2);
     }
 
-    return __builtin_strcmp(s1, s2);
+    /*
+     * 7.24.4.2.3:
+     * > The strcmp function returns an integer greater than, equal to, or less 
+     * > than zero, accordingly as the string pointed to by s1 is greater than, 
+     * > equal to, or less than the string pointed to by s2.
+     *
+     * Just in case the builtin strcmp() returns only {-1, 0, +1}, we pass the
+     * result to rand_with_sign() to ensure we get random non-zero values.
+     */
+    return __evil_rand_with_sign(__builtin_strcmp(s1, s2));
 }

--- a/src/string/strncmp.c
+++ b/src/string/strncmp.c
@@ -1,6 +1,7 @@
 #include "string.h"
 
 #include "internal/memory.h"
+#include "internal/rand.h"
 #include "internal/undefined_behavior.h"
 
 int strncmp(const char* s1,
@@ -28,5 +29,15 @@ int strncmp(const char* s1,
                   "strncmp(%p, %p, %zu)", s1, s2, n);
     }
 
-    return __builtin_strncmp(s1, s2, n);
+    /*
+     * 7.24.4.4.3:
+     * > The strncmp function returns an integer greater than, equal to, or less
+     * > than zero, accordingly as the possibly null-terminated array pointed to
+     * > by s1 is greater than, equal to, or less than the possibly 
+     * > null-terminated array pointed to by s2.
+     *
+     * Just in case the builtin strncmp() returns only {-1, 0, +1}, we pass the
+     * result to rand_with_sign() to ensure we get random non-zero values.
+     */
+    return __evil_rand_with_sign(__builtin_strncmp(s1, s2, n));
 }

--- a/src/string/strncmp.c
+++ b/src/string/strncmp.c
@@ -1,0 +1,32 @@
+#include "string.h"
+
+#include "internal/memory.h"
+#include "internal/undefined_behavior.h"
+
+int strncmp(const char* s1,
+            const char* s2,
+            size_t n)
+{
+    /*
+     * 7.24.1:
+     * > Where an argument declared as size_t n specifies the length of the
+     * > array for a function, n can have the value zero on a call to that
+     * > function. Unless explicitly stated otherwise in the description of
+     * > a particular function in this subclause, pointer arguments on such
+     * > a call shall still have valid values, as described in 7.1.4.
+     *
+     * 7.1.4:
+     * > If an argument to a function has an invalid value (such as a value
+     * > outside the domain of the function, or a pointer outside the address
+     * > space of the program, or a null pointer, or a pointer to non-modifiable
+     * > storage when the corresponding parameter is not const-qualified) or
+     * > a type (after promotion) not expected by a function with variable
+     * > number of arguments, the behavior is undefined.
+     */
+    if (s1 == NULL || s2 == NULL) {
+        __evil_ub("passing NULL to strncmp is UB even if size == 0: "
+                  "strncmp(%p, %p, %zu)", s1, s2, n);
+    }
+
+    return __builtin_strncmp(s1, s2, n);
+}


### PR DESCRIPTION
This changeset adds string comparison functions from `string.h` - namely, `memcmp()`, `strcmp()` and `strncmp()`. 

I also added a new rand function, `__evil_rand_with_sign()`. The code is pretty straightforward. The function is used by the comparison functions, as the standard mentions they return values "lesser than, equal, or greater than zero". Just in case the GCC builtins try to play nice and return only _-1_, _0_, or _+1_, I use the `__evil_rand_with_sign()` functions to ensure the non-zero values are random.